### PR TITLE
코드리뷰: graph, parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.o
+main
+data
+*.txt
+*.html
+*.png
+

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CXX = g++
-TARGET = <source code file>
-OBJECTS = <source code file>.o graph.o parse.o stat.o basicstat.o connectstat.o countstat.o plot.o makeplot.o html.o
+TARGET = main
+OBJECTS = main.o graph.o parse.o stat.o basicstat.o connectstat.o countstat.o plot.o makeplot.o html.o
 CXXFLAGS = -std=c++11 -Wall -O3
 LDFLAGS =
 

--- a/graph.cpp
+++ b/graph.cpp
@@ -74,7 +74,7 @@ namespace snu {
             Label_of_Edges *el;
 
             // no edge label class
-            if(it == elabel_to_class.end()) {
+            if (it == elabel_to_class.end()) {
                 el = new Label_of_Edges();
                 elabel_to_class[lbl[i]] = el;
                 el->label = lbl[i];

--- a/graph.cpp
+++ b/graph.cpp
@@ -1,117 +1,136 @@
 #include "graph.h"
 
+
 namespace snu {
 
-	Graph::Graph() {}
+    Graph::Graph() {}
 
-	/* destructor */
-	Graph::~Graph() {
-		// delete vertex, edge, vertex_label, edge_label;
-		for(auto it = id_to_vertex.begin(); it != id_to_vertex.end(); it++) delete it->second;
-		for(auto it = id_to_edge.begin(); it != id_to_edge.end(); it++) delete it->second;
-		for(auto it = vlabel_to_class.begin(); it != vlabel_to_class.end(); it++) delete it->second;
-		for(auto it = elabel_to_class.begin(); it != elabel_to_class.end(); it++) delete it->second;
-	}
+    /* destructor */
+    Graph::~Graph()
+    {
+        // delete vertex, edge, vertex_label, edge_label;
+        for (auto it = id_to_vertex.begin(); it != id_to_vertex.end(); ++it) delete it->second;
+        for (auto it = id_to_edge.begin(); it != id_to_edge.end(); ++it) delete it->second;
+        for (auto it = vlabel_to_class.begin(); it != vlabel_to_class.end(); ++it) delete it->second;
+        for (auto it = elabel_to_class.begin(); it != elabel_to_class.end(); ++it) delete it->second;
+    }
 
-	/* do not have to define destructor of child classes */
+    /* do not have to define destructor of child classes */
 
-	/* array version */
-	int Graph::add_vertex(Vid id, unsigned int num, Vlabel lbl[]) {
-		if(id_to_vertex.count(id)) return 1; // error: graph already has a vertex having same id
+    /* array version */
+    int Graph::add_vertex(Vid id, unsigned int num, Vlabel lbl[])
+    {
+        // error: graph already has a vertex having same id
+        if (id_to_vertex.count(id)) return 1;
 
-		Vertex *v = new Vertex(); // create vertex class
-		id_to_vertex[id] = v;
-		v->id = id; // set id
-		// set labels
-		// if no vertex label class then create it
-		for(unsigned int i = 0; i < num; i++) {
-			auto it = vlabel_to_class.find(lbl[i]);
-			Label_of_Vertices *vl;
+        Vertex *v = new Vertex();
+        id_to_vertex[id] = v;
+        v->id = id;
 
-			if(it == vlabel_to_class.end()) { // no vertex label class
-				vl = new Label_of_Vertices();
-				vlabel_to_class[lbl[i]] = vl;
-				vl->label = lbl[i];
-			}
-			else vl = it->second;
-			
-			vl->vertices.push_back(v);
-			v->labels.push_back(vl);
-		}
+        // set labels
+        // if no vertex label class then create it
+        for (unsigned int i = 0; i < num; ++i) {
+            auto it = vlabel_to_class.find(lbl[i]);
+            Label_of_Vertices *vl;
 
-		return 0;
-	}
+            // no vertex label class
+            if (it == vlabel_to_class.end()) {
+                vl = new Label_of_Vertices();
+                vlabel_to_class[lbl[i]] = vl;
+                vl->label = lbl[i];
+            }
+            else {
+                vl = it->second;
+            }
+            
+            vl->vertices.push_back(v);
+            v->labels.push_back(vl);
+        }
 
-	/* vector version */
-	int Graph::add_vertex(Vid id, std::vector <Vlabel> *lbl) {
-		return add_vertex(id, lbl->size(), lbl->data());
-	}
+        return 0;
+    }
 
-	/* base add_edge function, DSGraph version */
-	int Graph::add_edge(Eid id, unsigned int num, Elabel lbl[], Vid from, Vid to, Weight wgt) {
-		if(id_to_edge.count(id) || !id_to_vertex.count(from) || !id_to_vertex.count(to))
-			return 1;
-		// error: already have edge having same id or no from or to vertex
+    /* vector version */
+    int Graph::add_vertex(Vid id, std::vector <Vlabel> *lbl)
+    {
+        return add_vertex(id, lbl->size(), lbl->data());
+    }
 
-		Edge *e = new Edge(); // create edge class
-		id_to_edge[id] = e;
-		e->id = id; // set id
-		// set edge labels
-		// if no edge label class then create it
-		for(unsigned int i = 0; i < num; i++) {
-			auto it = elabel_to_class.find(lbl[i]);
-			Label_of_Edges *el;
+    /* base add_edge function, DSGraph version */
+    int Graph::add_edge(Eid id, unsigned int num, Elabel lbl[], Vid from, Vid to, Weight wgt) 
+    {
+        // error: already have edge having same id or no from or to vertex
+        if (id_to_edge.count(id) || !id_to_vertex.count(from) || !id_to_vertex.count(to))
+            return 1;
 
-			if(it == elabel_to_class.end()) { // no edge label class
-				el = new Label_of_Edges();
-				elabel_to_class[lbl[i]] = el;
-				el->label = lbl[i];
-			}
-			else el = it->second;
+        Edge *e = new Edge();
+        id_to_edge[id] = e;
+        e->id = id;
+        
+        // set edge labels
+        // if no edge label class then create it
+        for (unsigned int i = 0; i < num; ++i) {
+            auto it = elabel_to_class.find(lbl[i]);
+            Label_of_Edges *el;
 
-			el->edges.push_back(e);
-			e->labels.push_back(el);
-		}
-		e->from = id_to_vertex[from]; // set from
-		e->to = id_to_vertex[to]; // set to
-		e->to->indegree++; // increase indegree
-		e->wgt = wgt; // set weight
-		e->from->edges.push_back(e); // insert edge in from vertex
-		
-		is_connected.insert(std::make_pair(from, to)); // insert vertex pair
+            // no edge label class
+            if(it == elabel_to_class.end()) {
+                el = new Label_of_Edges();
+                elabel_to_class[lbl[i]] = el;
+                el->label = lbl[i];
+            }
+            else {
+                el = it->second;
+            }
 
-		if(wgt < 0) negative_edge_num++;
+            el->edges.push_back(e);
+            e->labels.push_back(el);
+        }
 
-		return 0;
-	}
+        e->from = id_to_vertex[from];
+        e->to = id_to_vertex[to];
+        e->to->indegree++;
+        e->wgt = wgt;
+        e->from->edges.push_back(e);
+        
+        is_connected.insert(std::make_pair(from, to));
 
-	/* array version */
-	int DSGraph::add_edge(Eid id, unsigned int num, Elabel lbl[], Vid from, Vid to, Weight wgt) {
-		if(Graph::add_edge(id, num, lbl, from, to, wgt)) return 1; // there is error
+        if (wgt < 0) negative_edge_num++;
 
-		return 0;
-	}
+        return 0;
+    }
 
-	/* vector version */
-	int DSGraph::add_edge(Eid id, std::vector <Elabel> *lbl, Vid from, Vid to, Weight wgt) {
-		return add_edge(id, lbl->size(), lbl->data(), from, to, wgt);
-	}
+    /* array version */
+    int DSGraph::add_edge(Eid id, unsigned int num, Elabel lbl[], Vid from, Vid to, Weight wgt)
+    {
+        return Graph::add_edge(id, num, lbl, from, to, wgt);
+    }
 
-	/* array version */
-	int USGraph::add_edge(Eid id, unsigned int num, Elabel lbl[], Vid from, Vid to, Weight wgt) {
-		if(Graph::add_edge(id, num, lbl, from, to, wgt)) return 1; // there is error
+    /* vector version */
+    int DSGraph::add_edge(Eid id, std::vector <Elabel> *lbl, Vid from, Vid to, Weight wgt)
+    {
+        return add_edge(id, lbl->size(), lbl->data(), from, to, wgt);
+    }
 
-		Edge *e = id_to_edge[id];
-		e->to->edges.push_back(e); // insert edge in to vertex
-		e->from->indegree++; // increase indegree of from
-		is_connected.insert(std::make_pair(to, from)); // insert reverse
-		// be careful of switching from and to in this case
+    /* array version */
+    int USGraph::add_edge(Eid id, unsigned int num, Elabel lbl[], Vid from, Vid to, Weight wgt)
+    {
+        // there is an error
+        if (Graph::add_edge(id, num, lbl, from, to, wgt)) return 1;
 
-		return 0;
-	}
+        Edge *e = id_to_edge[id];
+        e->to->edges.push_back(e);
+        e->from->indegree++;
+        is_connected.insert(std::make_pair(to, from));  // insert reverse
+                                                        // be careful of switching from and to in this case
 
-	/* vector version */
-	int USGraph::add_edge(Eid id, std::vector <Elabel> *lbl, Vid from, Vid to, Weight wgt) {
-		return add_edge(id, lbl->size(), lbl->data(), from, to, wgt);
-	}
+        return 0;
+    }
+
+    /* vector version */
+    int USGraph::add_edge(Eid id, std::vector <Elabel> *lbl, Vid from, Vid to, Weight wgt)
+    {
+        return add_edge(id, lbl->size(), lbl->data(), from, to, wgt);
+    }
 }
+

--- a/graph.h
+++ b/graph.h
@@ -8,125 +8,124 @@
 #include "stat.h"
 #include "plot.h"
 
+
 namespace snu {
 
-	class Graph; // graph having common aspects
-	class DSGraph; //   directed simple graph
-	class USGraph; // undirected simple graph
-	//class DMGraph; //   directed multigraph, not implemented
-	//class UMGraph; // undirected multigraph, not implemented
+    class Graph;    // graph having common aspects
+    class DSGraph;  // directed simple graph
+    class USGraph;  // undirected simple graph
 
-	typedef class Graph Graph;
-	typedef class DSGraph DSGraph;
-	typedef class USGraph USGraph;
+    typedef class Graph Graph;
+    typedef class DSGraph DSGraph;
+    typedef class USGraph USGraph;
 
-	class Graph {
-	protected:
-		typedef int Vid; // vertex id
-		typedef int Eid; // edge   id
-		typedef std::string Vlabel; // vertex label
-		typedef std::string Elabel; // edge   label
-		typedef int Weight; // integer type weight, other types of weight can be added
+    class Graph {
+    public:
+        typedef int Vid;             // vertex id
+        typedef int Eid;             // edge id
+        typedef std::string Vlabel;  // vertex label
+        typedef std::string Elabel;  // edge label
+        typedef int Weight;          // integer type weight, other types of weight can be added
 
-		class Vertex;
-		class Edge;
-		class Label_of_Vertices;
-		class Label_of_Edges;
+        class Vertex;
+        class Edge;
+        class Label_of_Vertices;
+        class Label_of_Edges;
 
-		class Vertex {
-		public:
-			Vid id;
-			std::list <Label_of_Vertices *> labels;
-			std::list <Edge *> edges;
-			unsigned int indegree;
-			void *temp;
-		};
+        class Vertex {
+        public:
+            Vid id;
+            std::list<Label_of_Vertices*> labels;
+            std::list<Edge*> edges;
+            unsigned int indegree;
+            void *temp;
+        };
 
-		class Edge {
-		public:
-			Eid id;
-			std::list <Label_of_Edges *> labels;
-			Vertex *from;
-			Vertex *to;
-			Weight wgt;
-			// If graph is undirected, then there is no difference between from and to.
-		};
+        class Edge {
+        public:
+            Eid id;
+            std::list<Label_of_Edges*> labels;
+            Vertex *from;  // In case of undirected graphs, there is no difference between from and to.
+            Vertex *to;
+            Weight wgt;
+        };
 
-		class Label_of_Vertices {
-		public:
-			Vlabel label;
-			std::list <Vertex *> vertices;
-		};
+        class Label_of_Vertices {
+        public:
+            Vlabel label;
+            std::list<Vertex*> vertices;
+        };
 
-		class Label_of_Edges {
-		public:
-			Elabel label;
-			std::list <Edge *> edges;
-		};
-	
-		std::unordered_map <Vid, Vertex *> id_to_vertex;
-		std::unordered_map <Eid, Edge *>   id_to_edge;
+        class Label_of_Edges {
+        public:
+            Elabel label;
+            std::list<Edge*> edges;
+        };
+    
+        std::unordered_map<Vid, Vertex*> id_to_vertex;
+        std::unordered_map<Eid, Edge*> id_to_edge;
 
-		std::unordered_map <Vlabel, Label_of_Vertices *> vlabel_to_class;
-		std::unordered_map <Elabel, Label_of_Edges *>    elabel_to_class;
+        std::unordered_map<Vlabel, Label_of_Vertices*> vlabel_to_class;
+        std::unordered_map<Elabel, Label_of_Edges*> elabel_to_class;
 
-		struct pair_hash {
-			inline unsigned long long operator()(const std::pair<Vid, Vid> &v) const {
-				return ((unsigned long long)v.first << 32) + v.second;
-			}
-		};
+        struct pair_hash {
+            inline unsigned long long operator()(const std::pair<Vid, Vid> &v) const {
+                return ((unsigned long long)v.first << 32) + v.second;
+            }
+        };
 
-		std::unordered_set <std::pair<Vid, Vid>, pair_hash> is_connected;
+        std::unordered_set<std::pair<Vid, Vid>, pair_hash> is_connected;
 
-		unsigned int negative_edge_num = 0;
-		char visit = 0;
+        unsigned int negative_edge_num = 0;
+        char visit = 0;
 
-		Graph(); // prevent from creating Graph class and allow creating graph in subclass
-		~Graph(); // destructor
+        Graph();   // prevent from creating Graph class and allow creating graph in subclass
+        ~Graph();  // destructor
 
-		int add_vertex(Vid id, unsigned int num, Vlabel lbl[]); // add vertex, array version
-		int add_vertex(Vid id, std::vector <Vlabel> *lbl); // vector version
-		// if vertex is created normally, then return 0
-		// if error occurs, then return 1
+        // add vertex
+        // if vertex is created normally, then return 0
+        // if error occurs, then return 1
+        int add_vertex(Vid id, unsigned int num, Vlabel lbl[]);  // array version
+        int add_vertex(Vid id, std::vector <Vlabel> *lbl);       // vector version
 
-		// directed form of add_edge
-		int add_edge(Eid id, unsigned int num, Elabel lbl[], Vid from, Vid to, Weight wgt); // array version
-		// if edge is created normally, then return 0
-		// if error occurs, then return 1
+        // directed form of add_edge
+        // if edge is created normally, then return 0
+        // if error occurs, then return 1
+        int add_edge(Eid id, unsigned int num, Elabel lbl[], Vid from, Vid to, Weight wgt);  // array version
 
-		// friend function
-		friend unsigned long long BFS(Graph::Vertex *start);
-	};
+        friend unsigned long long BFS(Graph::Vertex *start);
+    };
 
-	class DSGraph: public Graph { // directed simple graph
-	public:
-		int add_edge(Eid id, unsigned int num, Elabel lbl[], Vid from, Vid to, Weight wgt); // array version
-		int add_edge(Eid id, std::vector <Elabel> *lbl, Vid from, Vid to, Weight wgt); // vector version
+    // directed simple graph
+    class DSGraph: public Graph {
+    public:
+        int add_edge(Eid id, unsigned int num, Elabel lbl[], Vid from, Vid to, Weight wgt);  // array version
+        int add_edge(Eid id, std::vector <Elabel> *lbl, Vid from, Vid to, Weight wgt);       // vector version
 
-		// friend function
-		friend void basic_stat(DSGraph *graph, DSResult *result);
-		friend void connect_stat(DSGraph *graph, DSResult *result);
-		friend void make_plot(DSGraph *graph, Plot *plot);
-		
-		friend DSGraph *parse_snu_DSGraph(std::string file_path);
-		friend DSGraph *parse_net_DSGraph(std::string file_path);
-		friend DSGraph *parse_snap_DSGraph(std::string file_path);
-	};
+        friend void basic_stat(DSGraph *graph, DSResult *result);
+        friend void connect_stat(DSGraph *graph, DSResult *result);
+        friend void make_plot(DSGraph *graph, Plot *plot);
+        
+        friend DSGraph *parse_snu_DSGraph(std::string file_path);
+        friend DSGraph *parse_net_DSGraph(std::string file_path);
+        friend DSGraph *parse_snap_DSGraph(std::string file_path);
+    };
 
-	class USGraph: public Graph { // undirected simple graph
-	public:
-		int add_edge(Eid id, unsigned int num, Elabel lbl[], Vid from, Vid to, Weight wgt); // array version
-		int add_edge(Eid id, std::vector <Elabel> *lbl, Vid from, Vid to, Weight wgt); // vector version
+    // undirected simple graph
+    class USGraph: public Graph {
+    public:
+        int add_edge(Eid id, unsigned int num, Elabel lbl[], Vid from, Vid to, Weight wgt);  // array version
+        int add_edge(Eid id, std::vector <Elabel> *lbl, Vid from, Vid to, Weight wgt);       // vector version
 
-		// friend function
-		friend void basic_stat(USGraph *graph, USResult *result);
-		friend void connect_stat(USGraph *graph, USResult *result);
-		friend void count_stat(USGraph *graph, USResult *result);
-		friend void make_plot(USGraph *graph, Plot *plot);
+        friend void basic_stat(USGraph *graph, USResult *result);
+        friend void connect_stat(USGraph *graph, USResult *result);
+        friend void count_stat(USGraph *graph, USResult *result);
+        friend void make_plot(USGraph *graph, Plot *plot);
 
-		friend USGraph *parse_snu_USGraph(std::string file_path);
-		friend USGraph *parse_snap_USGraph(std::string file_path);
-	};
+        friend USGraph *parse_snu_USGraph(std::string file_path);
+        friend USGraph *parse_snap_USGraph(std::string file_path);
+    };
 }
 
 #endif // GRAPH_H
+

--- a/parse.cpp
+++ b/parse.cpp
@@ -3,240 +3,259 @@
 #include <algorithm>
 #include "parse.h"
 
+
 namespace snu {
 
-	// parse .snu file
-	DSGraph *parse_snu_DSGraph(std::string file_path) {
-		std::ifstream infile(file_path);
-		std::string line;
-		DSGraph *graph = new DSGraph();
-		Graph::Eid eid = 0;
+    // parse .snu file
+    DSGraph *parse_snu_DSGraph(std::string file_path)
+    {
+        std::ifstream infile(file_path);
+        std::string line;
+        DSGraph *graph = new DSGraph();
+        Graph::Eid eid = 0;
 
-		while(getline(infile, line)) {
-			std::istringstream iss(line);
+        while (getline(infile, line)) {
+            std::istringstream iss(line);
 
-			std::string sign;
-			iss >> sign;
-			if(sign == "t") {}
-			else if(sign == "v") {
-				Graph::Vid id;
-				Graph::Vlabel label;
-				std::vector <Graph::Vlabel> label_vector;
+            std::string sign;
+            iss >> sign;
+            if (sign == "t") {}
+            else if (sign == "v") {
+                Graph::Vid id;
+                Graph::Vlabel label;
+                std::vector <Graph::Vlabel> label_vector;
 
-				iss >> id;
-				while(iss >> label) label_vector.push_back(label);
-				if(graph->add_vertex(id, &label_vector)) { // error
-					delete graph;
-					return NULL;
-				}
-			}
-			else if(sign == "e") {
-				Graph::Vid from, to;
-				Graph::Elabel label;
-				std::vector<Graph::Elabel> label_vector;
+                iss >> id;
+                while (iss >> label) label_vector.push_back(label);
 
-				iss >> from >> to;
-				while(iss >> label) label_vector.push_back(label);
-				if(graph->add_edge(eid++, &label_vector, from, to, 1)) { // error
-					delete graph;
-					return NULL;
-				}
-			}
-			else { // error
-				delete graph;
-				return NULL;
-			}
-		}
+                // error
+                if (graph->add_vertex(id, &label_vector)) {
+                    delete graph;
+                    return NULL;
+                }
+            }
+            else if (sign == "e") {
+                Graph::Vid from, to;
+                Graph::Elabel label;
+                std::vector<Graph::Elabel> label_vector;
 
-		return graph;
-	}
+                iss >> from >> to;
+                while (iss >> label) label_vector.push_back(label);
 
-	// parse .net file
-	DSGraph *parse_net_DSGraph(std::string file_path) {
-		DSGraph *graph = new DSGraph();
-		std::ifstream infile(file_path);
-		std::string line;
-		int check_vertex = 0;
-		int check_edge = 0;
+                // error
+                if (graph->add_edge(eid++, &label_vector, from, to, 1)) {
+                    delete graph;
+                    return nullptr;
+                }
+            }
+            else {
+                delete graph;
+                return nullptr;
+            }
+        }
 
-		while(getline(infile, line)) {
-			std::istringstream iss(line);
+        return graph;
+    }
 
-			if(line.find("*Vertices") != std::string::npos || line.find("*vertices") != std::string::npos) {
-				check_vertex = 1;
-				check_edge = 0;
-				continue;
-			}
-			else if(line.find("*arcs") != std::string::npos || line.find("*Arcs") != std::string::npos) {
-				check_edge = 1;
-				check_vertex = 0;
-				continue;
-			}
+    // parse .net file
+    DSGraph *parse_net_DSGraph(std::string file_path) 
+    {
+        DSGraph *graph = new DSGraph();
+        std::ifstream infile(file_path);
+        std::string line;
+        int check_vertex = 0;
+        int check_edge = 0;
 
-			if(check_vertex==1) {
-				Graph::Vid id;
-				std::vector <Graph::Vlabel> label_vector;
-				Graph::Vlabel label;
-				iss >> id;
+        while (getline(infile, line)) {
+            std::istringstream iss(line);
 
-				while(iss >> label) {
-					label.erase(std::remove(label.begin(), label.end(), '\"'), label.end());
-					label_vector.push_back(label);
-				}
-				graph->add_vertex(id, &label_vector);
-			}
+            if (line.find("*Vertices") != std::string::npos || line.find("*vertices") != std::string::npos) {
+                check_vertex = 1;
+                check_edge = 0;
+                continue;
+            }
+            else if (line.find("*arcs") != std::string::npos || line.find("*Arcs") != std::string::npos) {
+                check_edge = 1;
+                check_vertex = 0;
+                continue;
+            }
 
-			if(check_edge==1) {
-				Graph::Eid id;
-				Graph::Vid from;
-				Graph::Vid to;
-				std::vector <Graph::Elabel> label_vector;
-				Graph::Elabel label;
+            if (check_vertex==1) {
+                Graph::Vid id;
+                std::vector <Graph::Vlabel> label_vector;
+                Graph::Vlabel label;
+                iss >> id;
 
-				iss >> id;
-				iss >> from;
-				iss >> to;
-				while(iss >> label){
-					if(label == "l") continue;
-					label.erase(std::remove(label.begin(), label.end(), '\"'), label.end());
-					label_vector.push_back(label);
-				}
-				graph->add_edge(id, &label_vector, from, to, 1);
-			}
-		}
-		return graph;
-	}
+                while (iss >> label) {
+                    label.erase(std::remove(label.begin(), label.end(), '\"'), label.end());
+                    label_vector.push_back(label);
+                }
+                graph->add_vertex(id, &label_vector);
+            }
 
-	// parse .snap file
-	DSGraph *parse_snap_DSGraph(std::string file_path) {
-		std::ifstream infile(file_path);
-		std::string line;
-		DSGraph *graph = new DSGraph();
-		std::unordered_set <int> set;
-		Graph::Eid eid = 0;
+            if (check_edge==1) {
+                Graph::Eid id;
+                Graph::Vid from;
+                Graph::Vid to;
+                std::vector <Graph::Elabel> label_vector;
+                Graph::Elabel label;
 
-		while(getline(infile, line)) {
-			std::istringstream iss(line);
+                iss >> id;
+                iss >> from;
+                iss >> to;
+                while (iss >> label) {
+                    if (label == "l") continue;
+                    label.erase(std::remove(label.begin(), label.end(), '\"'), label.end());
+                    label_vector.push_back(label);
+                }
+                graph->add_edge(id, &label_vector, from, to, 1);
+            }
+        }
 
-			if(line.find("#") != std::string::npos)
-				continue;
+        return graph;
+    }
 
-			Graph::Vid from, to;
-			iss >> from >> to;
+    // parse .snap file
+    DSGraph *parse_snap_DSGraph(std::string file_path) 
+    {
+        std::ifstream infile(file_path);
+        std::string line;
+        DSGraph *graph = new DSGraph();
+        std::unordered_set <int> set;
+        Graph::Eid eid = 0;
 
-			if(!set.count(from)) {
-				set.insert(from);
-				graph->add_vertex(from, 0, NULL);
-			}
-			if(!set.count(to)) {
-				set.insert(to);
-				graph->add_vertex(to, 0, NULL);
-			}
+        while (getline(infile, line)) {
+            std::istringstream iss(line);
 
-			// add edge
-			graph->add_edge(eid++, 0, NULL, from, to, 1);
-		}
+            if (line.find("#") != std::string::npos)
+                continue;
 
-		return graph;
-	}
+            Graph::Vid from, to;
+            iss >> from >> to;
 
-	// parsing DSGraph version follows
-	DSGraph *parse_DSGraph(std::string file_path) {
-		if(file_path.rfind(".snu") == file_path.length() - 4)
-			return parse_snu_DSGraph(file_path);
-		else if(file_path.rfind(".snap") == file_path.length() - 5)
-			return parse_snap_DSGraph(file_path);
-		else if(file_path.rfind(".net") == file_path.length() - 4)
-			return parse_net_DSGraph(file_path);
-		// else if
-		return NULL; // failed
-	}
+            if (!set.count(from)) {
+                set.insert(from);
+                graph->add_vertex(from, 0, NULL);
+            }
 
-	USGraph *parse_snu_USGraph(std::string file_path) {
-		std::ifstream infile(file_path);
-		std::string line;
-		USGraph *graph = new USGraph();
-		Graph::Eid eid = 0;
+            if (!set.count(to)) {
+                set.insert(to);
+                graph->add_vertex(to, 0, NULL);
+            }
 
-		while(getline(infile, line)) {
-			std::istringstream iss(line);
+            graph->add_edge(eid++, 0, NULL, from, to, 1);
+        }
 
-			std::string sign;
-			iss >> sign;
-			if(sign == "t") {}
-			else if(sign == "v") {
-				Graph::Vid id;
-				Graph::Vlabel label;
-				std::vector <Graph::Vlabel> label_vector;
+        return graph;
+    }
 
-				iss >> id;
-				while(iss >> label) label_vector.push_back(label);
-				if(graph->add_vertex(id, &label_vector)) { // error
-					delete graph;
-					return NULL;
-				}
-			}
-			else if(sign == "e") {
-				Graph::Vid from, to;
-				Graph::Elabel label;
-				std::vector<Graph::Elabel> label_vector;
+    // parsing DSGraph version follows
+    DSGraph *parse_DSGraph(std::string file_path)
+    {
+        if (file_path.rfind(".snu") == file_path.length() - 4)
+            return parse_snu_DSGraph(file_path);
+        else if (file_path.rfind(".snap") == file_path.length() - 5)
+            return parse_snap_DSGraph(file_path);
+        else if (file_path.rfind(".net") == file_path.length() - 4)
+            return parse_net_DSGraph(file_path);
 
-				iss >> from >> to;
-				while(iss >> label) label_vector.push_back(label);
-				if(graph->add_edge(eid++, &label_vector, from, to, 1)) { // error
-					delete graph;
-					return NULL;
-				}
-			}
-			else { // error
-				delete graph;
-				return NULL;
-			}
-		}
+        // failed
+        return nullptr;
+    }
 
-		return graph;
-	}
+    USGraph *parse_snu_USGraph(std::string file_path)
+    {
+        std::ifstream infile(file_path);
+        std::string line;
+        USGraph *graph = new USGraph();
+        Graph::Eid eid = 0;
 
-	USGraph *parse_snap_USGraph(std::string file_path) {
-		std::ifstream infile(file_path);
-		std::string line;
-		USGraph *graph = new USGraph();
-		std::unordered_set <int> set;
-		Graph::Eid eid = 0;
+        while (getline(infile, line)) {
+            std::istringstream iss(line);
 
-		while(getline(infile, line)) {
-			std::istringstream iss(line);
+            std::string sign;
+            iss >> sign;
+            if (sign == "t") {}
+            else if (sign == "v") {
+                Graph::Vid id;
+                Graph::Vlabel label;
+                std::vector<Graph::Vlabel> label_vector;
 
-			if(line.find("#") != std::string::npos)
-				continue;
+                iss >> id;
+                while (iss >> label) label_vector.push_back(label);
 
-			Graph::Vid from, to;
-			iss >> from >> to;
+                // error
+                if (graph->add_vertex(id, &label_vector)) {
+                    delete graph;
+                    return nullptr;
+                }
+            }
+            else if (sign == "e") {
+                Graph::Vid from, to;
+                Graph::Elabel label;
+                std::vector<Graph::Elabel> label_vector;
 
-			if(!set.count(from)) {
-				set.insert(from);
-				graph->add_vertex(from, 0, NULL);
-			}
-			if(!set.count(to)) {
-				set.insert(to);
-				graph->add_vertex(to, 0, NULL);
-			}
+                iss >> from >> to;
+                while (iss >> label) label_vector.push_back(label);
 
-			// add edge
-			graph->add_edge(eid++, 0, NULL, from, to, 1);
-		}
+                // error
+                if (graph->add_edge(eid++, &label_vector, from, to, 1)) {
+                    delete graph;
+                    return nullptr;
+                }
+            }
+            else {
+                delete graph;
+                return nullptr;
+            }
+        }
 
-		return graph;
-	}
+        return graph;
+    }
 
-	USGraph *parse_USGraph(std::string file_path) {
-		if(file_path.rfind(".snu") == file_path.length() - 4)
-			return parse_snu_USGraph(file_path); // error
-		else if(file_path.rfind(".snap") == file_path.length() - 5)
-			return parse_snap_USGraph(file_path); // error
-		else if(file_path.rfind(".net") == file_path.length() - 4)
-			return NULL; // error
-		// else if
-		return NULL; // failed
-	}
+    USGraph *parse_snap_USGraph(std::string file_path) 
+    {
+        std::ifstream infile(file_path);
+        std::string line;
+        USGraph *graph = new USGraph();
+        std::unordered_set<int> set;
+        Graph::Eid eid = 0;
+
+        while (getline(infile, line)) {
+            std::istringstream iss(line);
+
+            if (line.find("#") != std::string::npos)
+                continue;
+
+            Graph::Vid from, to;
+            iss >> from >> to;
+
+            if (!set.count(from)) {
+                set.insert(from);
+                graph->add_vertex(from, 0, NULL);
+            }
+
+            if (!set.count(to)) {
+                set.insert(to);
+                graph->add_vertex(to, 0, NULL);
+            }
+
+            graph->add_edge(eid++, 0, NULL, from, to, 1);
+        }
+
+        return graph;
+    }
+
+    USGraph *parse_USGraph(std::string file_path) 
+    {
+        if (file_path.rfind(".snu") == file_path.length() - 4)
+            return parse_snu_USGraph(file_path);
+        else if (file_path.rfind(".snap") == file_path.length() - 5)
+            return parse_snap_USGraph(file_path);
+        else if (file_path.rfind(".net") == file_path.length() - 4)
+            return nullptr;
+
+        return nullptr;
+    }
 }
+

--- a/parse.h
+++ b/parse.h
@@ -4,10 +4,12 @@
 #include "graph.h"
 #include <string>
 
+
 namespace snu {
 
-	DSGraph *parse_DSGraph(std::string file_path);
-	USGraph *parse_USGraph(std::string file_path);
+    DSGraph *parse_DSGraph(std::string file_path);
+    USGraph *parse_USGraph(std::string file_path);
 }
 
 #endif // PARSE_H
+


### PR DESCRIPTION
`graph.h`, `graph.cpp`, `parse.h`, `parse.cpp`의 코드를 읽고 코딩 컨벤션에 맞게 수정했습니다.
코드의 로직은 손 대지 않고, 괄호나 주석의 형태 등만 프로젝트의 스타일 가이드에 맞게 수정했습니다.
프로젝트의 스타일 가이드에 해당 사항이 없는 경우 Google의 스타일 가이드를 따랐습니다.

프로젝트의 스타일 가이드에 따른 수정 사항들은 아래와 같습니다.
- 개행을 tab이 아닌 4개의 space로 고쳤습니다.
- 함수의 여는 괄호를 다음 줄로 넘겼습니다.
- 괄호의 앞과 뒤에 공백을 추가했습니다.

Google의 스타일 가이드에 따른 수정 사항들은 아래와 같습니다.
- 자명한(불필요한) 주석들을 삭제했습니다.
- 구문의 주석을 구문의 옆이나 아래가 아닌 구문의 위로 옮겼습니다.
- 인접한 주석들이 같은 열에서 시작하도록 정돈했습니다.
- 코드와 같은 행에 주석이 작성된 경우 둘 사이에 두 칸의 공백을 두었습니다.
- `if-else` 문의 `if` 부분이나 `else` 부분 어느 한 쪽에만 중괄호가 사용된 경우에 두 부분 모두 중괄호를 사용하도록 수정했습니다.

그 밖의 수정사항들은 아래와 같습니다.
- `int`등의 primitive type은 해당사항이 없지만 `iterator`를 비롯한 template type에 post-increment를 사용하는 것은 성능상의 이슈가 있다고 알고 있습니다. 루프 안에서 `iterator`에 post-increment를 사용한 경우 이를 pre-increment로 수정했습니다.
- 각 파일의 끝에 빈 줄을 추가했습니다.