### PR TITLE
코드개선: main, parse 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.o
 main
 data
+pyplot
 *.txt
 *.html
 *.png

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,4 @@
 #include <stdio.h>
-#include <string.h>
 #include <getopt.h>
 #include "snugal.h"
 

--- a/parse.cpp
+++ b/parse.cpp
@@ -7,7 +7,7 @@
 namespace snu {
 
     // parse .snu file
-    int parse_snu_DSGraph(std::string file_path, DSGraph& graph)
+    int parseDSGraphSNU(std::string file_path, DSGraph& graph)
     {
         std::ifstream infile(file_path);
         if (infile.fail()) {
@@ -48,9 +48,10 @@ namespace snu {
                     label_vector.push_back(label);
                 }
 
-                if (graph.add_edge(eid++, &label_vector, from, to, 1)) {
+                if (graph.add_edge(eid, &label_vector, from, to, 1)) {
                     return PARSE_FAILURE_ADD_EDGE;
                 }
+                ++eid;
             }
             else {
                 return PARSE_FAILURE_INVALID_INPUT;
@@ -61,7 +62,7 @@ namespace snu {
     }
 
     // parse .net file
-    int parse_net_DSGraph(std::string file_path, DSGraph& graph) 
+    int parseDSGraphNET(std::string file_path, DSGraph& graph) 
     {
         std::ifstream infile(file_path);
         if (infile.fail()) {
@@ -69,24 +70,24 @@ namespace snu {
         }
 
         std::string line;
-        int check_vertex = 0;
-        int check_edge = 0;
+        bool check_vertex = false;
+        bool check_edge = false;
 
         while (getline(infile, line)) {
             std::istringstream iss(line);
 
             if (line.find("*Vertices") != std::string::npos || line.find("*vertices") != std::string::npos) {
-                check_vertex = 1;
-                check_edge = 0;
+                check_vertex = true;
+                check_edge = false;
                 continue;
             }
             else if (line.find("*arcs") != std::string::npos || line.find("*Arcs") != std::string::npos) {
-                check_edge = 1;
-                check_vertex = 0;
+                check_edge = true;
+                check_vertex = false;
                 continue;
             }
 
-            if (check_vertex==1) {
+            if (check_vertex) {
                 Graph::Vid id;
                 std::vector <Graph::Vlabel> label_vector;
                 Graph::Vlabel label;
@@ -102,16 +103,14 @@ namespace snu {
                 }
             }
 
-            if (check_edge==1) {
+            if (check_edge) {
                 Graph::Eid id;
                 Graph::Vid from;
                 Graph::Vid to;
                 std::vector <Graph::Elabel> label_vector;
                 Graph::Elabel label;
 
-                iss >> id;
-                iss >> from;
-                iss >> to;
+                iss >> id >> from >> to;
                 while (iss >> label) {
                     if (label == "l") continue;
                     label.erase(std::remove(label.begin(), label.end(), '\"'), label.end());
@@ -128,7 +127,7 @@ namespace snu {
     }
 
     // parse .snap file
-    int parse_snap_DSGraph(std::string file_path, DSGraph& graph)
+    int parseDSGraphSNAP(std::string file_path, DSGraph& graph)
     {
         std::ifstream infile(file_path);
         if (infile.fail()) {
@@ -162,28 +161,29 @@ namespace snu {
                 }
             }
 
-            if (graph.add_edge(eid++, 0, NULL, from, to, 1)) {
+            if (graph.add_edge(eid, 0, NULL, from, to, 1)) {
                 return PARSE_FAILURE_ADD_EDGE;
             }
+            ++eid;
         }
 
         return PARSE_SUCCESS;
     }
 
     // parsing DSGraph version follows
-    int parse_DSGraph(std::string file_path, DSGraph& graph)
+    int parseDSGraph(std::string file_path, DSGraph& graph)
     {
         if (file_path.rfind(".snu") == file_path.length() - 4)
-            return parse_snu_DSGraph(file_path, graph);
+            return parseDSGraphSNU(file_path, graph);
         else if (file_path.rfind(".snap") == file_path.length() - 5)
-            return parse_snap_DSGraph(file_path, graph);
+            return parseDSGraphSNAP(file_path, graph);
         else if (file_path.rfind(".net") == file_path.length() - 4)
-            return parse_net_DSGraph(file_path, graph);
+            return parseDSGraphNET(file_path, graph);
 
         return PARSE_FAILURE_INVALID_FILETYPE;
     }
 
-    int parse_snu_USGraph(std::string file_path, USGraph& graph)
+    int parseUSGraphSNU(std::string file_path, USGraph& graph)
     {
         std::ifstream infile(file_path);
         if (infile.fail()) {
@@ -223,9 +223,10 @@ namespace snu {
                     label_vector.push_back(label);
                 }
 
-                if (graph.add_edge(eid++, &label_vector, from, to, 1)) {
+                if (graph.add_edge(eid, &label_vector, from, to, 1)) {
                     return PARSE_FAILURE_ADD_EDGE;
                 }
+                ++eid;
             }
             else {
                 return PARSE_FAILURE_INVALID_INPUT;
@@ -235,7 +236,7 @@ namespace snu {
         return PARSE_SUCCESS;
     }
 
-    int parse_snap_USGraph(std::string file_path, USGraph& graph)
+    int parseUSGraphSNAP(std::string file_path, USGraph& graph)
     {
         std::ifstream infile(file_path);
         if (infile.fail()) {
@@ -249,8 +250,9 @@ namespace snu {
         while (getline(infile, line)) {
             std::istringstream iss(line);
 
-            if (line.find("#") != std::string::npos)
+            if (line.find("#") != std::string::npos) {
                 continue;
+            }
 
             Graph::Vid from, to;
             iss >> from >> to;
@@ -269,20 +271,21 @@ namespace snu {
                 }
             }
 
-            if (graph.add_edge(eid++, 0, NULL, from, to, 1)) {
+            if (graph.add_edge(eid, 0, NULL, from, to, 1)) {
                 return PARSE_FAILURE_ADD_EDGE;
             }
+            ++eid;
         }
 
         return PARSE_SUCCESS;
     }
 
-    int parse_USGraph(std::string file_path, USGraph& graph)
+    int parseUSGraph(std::string file_path, USGraph& graph)
     {
         if (file_path.rfind(".snu") == file_path.length() - 4)
-            return parse_snu_USGraph(file_path, graph);
+            return parseUSGraphSNU(file_path, graph);
         else if (file_path.rfind(".snap") == file_path.length() - 5)
-            return parse_snap_USGraph(file_path, graph);
+            return parseUSGraphSNAP(file_path, graph);
         else if (file_path.rfind(".net") == file_path.length() - 4)
             return PARSE_FAILURE_INVALID_FILETYPE;
 

--- a/parse.cpp
+++ b/parse.cpp
@@ -7,11 +7,14 @@
 namespace snu {
 
     // parse .snu file
-    DSGraph *parse_snu_DSGraph(std::string file_path)
+    int parse_snu_DSGraph(std::string file_path, DSGraph& graph)
     {
         std::ifstream infile(file_path);
+        if (infile.fail()) {
+            return PARSE_FAILURE_NO_INPUT;
+        }
+
         std::string line;
-        DSGraph *graph = new DSGraph();
         Graph::Eid eid = 0;
 
         while (getline(infile, line)) {
@@ -19,6 +22,7 @@ namespace snu {
 
             std::string sign;
             iss >> sign;
+            
             if (sign == "t") {}
             else if (sign == "v") {
                 Graph::Vid id;
@@ -26,12 +30,12 @@ namespace snu {
                 std::vector <Graph::Vlabel> label_vector;
 
                 iss >> id;
-                while (iss >> label) label_vector.push_back(label);
+                while (iss >> label) {
+                    label_vector.push_back(label);
+                }
 
-                // error
-                if (graph->add_vertex(id, &label_vector)) {
-                    delete graph;
-                    return NULL;
+                if (graph.add_vertex(id, &label_vector)) {
+                    return PARSE_FAILURE_ADD_VERTEX;
                 }
             }
             else if (sign == "e") {
@@ -40,28 +44,30 @@ namespace snu {
                 std::vector<Graph::Elabel> label_vector;
 
                 iss >> from >> to;
-                while (iss >> label) label_vector.push_back(label);
+                while (iss >> label) {
+                    label_vector.push_back(label);
+                }
 
-                // error
-                if (graph->add_edge(eid++, &label_vector, from, to, 1)) {
-                    delete graph;
-                    return nullptr;
+                if (graph.add_edge(eid++, &label_vector, from, to, 1)) {
+                    return PARSE_FAILURE_ADD_EDGE;
                 }
             }
             else {
-                delete graph;
-                return nullptr;
+                return PARSE_FAILURE_INVALID_INPUT;
             }
         }
 
-        return graph;
+        return PARSE_SUCCESS;
     }
 
     // parse .net file
-    DSGraph *parse_net_DSGraph(std::string file_path) 
+    int parse_net_DSGraph(std::string file_path, DSGraph& graph) 
     {
-        DSGraph *graph = new DSGraph();
         std::ifstream infile(file_path);
+        if (infile.fail()) {
+            return PARSE_FAILURE_NO_INPUT;
+        }
+
         std::string line;
         int check_vertex = 0;
         int check_edge = 0;
@@ -90,7 +96,10 @@ namespace snu {
                     label.erase(std::remove(label.begin(), label.end(), '\"'), label.end());
                     label_vector.push_back(label);
                 }
-                graph->add_vertex(id, &label_vector);
+
+                if (graph.add_vertex(id, &label_vector)) {
+                    return PARSE_FAILURE_ADD_VERTEX;
+                }
             }
 
             if (check_edge==1) {
@@ -108,19 +117,25 @@ namespace snu {
                     label.erase(std::remove(label.begin(), label.end(), '\"'), label.end());
                     label_vector.push_back(label);
                 }
-                graph->add_edge(id, &label_vector, from, to, 1);
+
+                if (graph.add_edge(id, &label_vector, from, to, 1)) {
+                    return PARSE_FAILURE_ADD_EDGE;
+                }
             }
         }
 
-        return graph;
+        return PARSE_SUCCESS;
     }
 
     // parse .snap file
-    DSGraph *parse_snap_DSGraph(std::string file_path) 
+    int parse_snap_DSGraph(std::string file_path, DSGraph& graph)
     {
         std::ifstream infile(file_path);
+        if (infile.fail()) {
+            return PARSE_FAILURE_NO_INPUT;
+        }
+
         std::string line;
-        DSGraph *graph = new DSGraph();
         std::unordered_set <int> set;
         Graph::Eid eid = 0;
 
@@ -135,39 +150,47 @@ namespace snu {
 
             if (!set.count(from)) {
                 set.insert(from);
-                graph->add_vertex(from, 0, NULL);
+                if (graph.add_vertex(from, 0, NULL)) {
+                    return PARSE_FAILURE_ADD_VERTEX;
+                }
             }
 
             if (!set.count(to)) {
                 set.insert(to);
-                graph->add_vertex(to, 0, NULL);
+                if (graph.add_vertex(to, 0, NULL)) {
+                    return PARSE_FAILURE_ADD_VERTEX;
+                }
             }
 
-            graph->add_edge(eid++, 0, NULL, from, to, 1);
+            if (graph.add_edge(eid++, 0, NULL, from, to, 1)) {
+                return PARSE_FAILURE_ADD_EDGE;
+            }
         }
 
-        return graph;
+        return PARSE_SUCCESS;
     }
 
     // parsing DSGraph version follows
-    DSGraph *parse_DSGraph(std::string file_path)
+    int parse_DSGraph(std::string file_path, DSGraph& graph)
     {
         if (file_path.rfind(".snu") == file_path.length() - 4)
-            return parse_snu_DSGraph(file_path);
+            return parse_snu_DSGraph(file_path, graph);
         else if (file_path.rfind(".snap") == file_path.length() - 5)
-            return parse_snap_DSGraph(file_path);
+            return parse_snap_DSGraph(file_path, graph);
         else if (file_path.rfind(".net") == file_path.length() - 4)
-            return parse_net_DSGraph(file_path);
+            return parse_net_DSGraph(file_path, graph);
 
-        // failed
-        return nullptr;
+        return PARSE_FAILURE_INVALID_FILETYPE;
     }
 
-    USGraph *parse_snu_USGraph(std::string file_path)
+    int parse_snu_USGraph(std::string file_path, USGraph& graph)
     {
         std::ifstream infile(file_path);
+        if (infile.fail()) {
+            return PARSE_FAILURE_NO_INPUT;
+        }
+
         std::string line;
-        USGraph *graph = new USGraph();
         Graph::Eid eid = 0;
 
         while (getline(infile, line)) {
@@ -182,12 +205,12 @@ namespace snu {
                 std::vector<Graph::Vlabel> label_vector;
 
                 iss >> id;
-                while (iss >> label) label_vector.push_back(label);
+                while (iss >> label) {
+                    label_vector.push_back(label);
+                }
 
-                // error
-                if (graph->add_vertex(id, &label_vector)) {
-                    delete graph;
-                    return nullptr;
+                if (graph.add_vertex(id, &label_vector)) {
+                    return PARSE_FAILURE_ADD_VERTEX;
                 }
             }
             else if (sign == "e") {
@@ -196,28 +219,30 @@ namespace snu {
                 std::vector<Graph::Elabel> label_vector;
 
                 iss >> from >> to;
-                while (iss >> label) label_vector.push_back(label);
+                while (iss >> label) {
+                    label_vector.push_back(label);
+                }
 
-                // error
-                if (graph->add_edge(eid++, &label_vector, from, to, 1)) {
-                    delete graph;
-                    return nullptr;
+                if (graph.add_edge(eid++, &label_vector, from, to, 1)) {
+                    return PARSE_FAILURE_ADD_EDGE;
                 }
             }
             else {
-                delete graph;
-                return nullptr;
+                return PARSE_FAILURE_INVALID_INPUT;
             }
         }
 
-        return graph;
+        return PARSE_SUCCESS;
     }
 
-    USGraph *parse_snap_USGraph(std::string file_path) 
+    int parse_snap_USGraph(std::string file_path, USGraph& graph)
     {
         std::ifstream infile(file_path);
+        if (infile.fail()) {
+            return PARSE_FAILURE_NO_INPUT;
+        }
+
         std::string line;
-        USGraph *graph = new USGraph();
         std::unordered_set<int> set;
         Graph::Eid eid = 0;
 
@@ -232,30 +257,36 @@ namespace snu {
 
             if (!set.count(from)) {
                 set.insert(from);
-                graph->add_vertex(from, 0, NULL);
+                if (graph.add_vertex(from, 0, NULL)) {
+                    return PARSE_FAILURE_ADD_VERTEX;
+                }
             }
 
             if (!set.count(to)) {
                 set.insert(to);
-                graph->add_vertex(to, 0, NULL);
+                if (graph.add_vertex(to, 0, NULL)) {
+                    return PARSE_FAILURE_ADD_VERTEX;
+                }
             }
 
-            graph->add_edge(eid++, 0, NULL, from, to, 1);
+            if (graph.add_edge(eid++, 0, NULL, from, to, 1)) {
+                return PARSE_FAILURE_ADD_EDGE;
+            }
         }
 
-        return graph;
+        return PARSE_SUCCESS;
     }
 
-    USGraph *parse_USGraph(std::string file_path) 
+    int parse_USGraph(std::string file_path, USGraph& graph)
     {
         if (file_path.rfind(".snu") == file_path.length() - 4)
-            return parse_snu_USGraph(file_path);
+            return parse_snu_USGraph(file_path, graph);
         else if (file_path.rfind(".snap") == file_path.length() - 5)
-            return parse_snap_USGraph(file_path);
+            return parse_snap_USGraph(file_path, graph);
         else if (file_path.rfind(".net") == file_path.length() - 4)
-            return nullptr;
+            return PARSE_FAILURE_INVALID_FILETYPE;
 
-        return nullptr;
+        return PARSE_FAILURE_INVALID_FILETYPE;
     }
 }
 

--- a/parse.h
+++ b/parse.h
@@ -7,8 +7,15 @@
 
 namespace snu {
 
-    DSGraph *parse_DSGraph(std::string file_path);
-    USGraph *parse_USGraph(std::string file_path);
+    const int PARSE_SUCCESS = 0;
+    const int PARSE_FAILURE_NO_INPUT = 1;
+    const int PARSE_FAILURE_INVALID_INPUT = 2;
+    const int PARSE_FAILURE_INVALID_FILETYPE = 3;
+    const int PARSE_FAILURE_ADD_VERTEX = 4;
+    const int PARSE_FAILURE_ADD_EDGE = 5;
+
+    int parse_DSGraph(std::string file_path, DSGraph& graph);
+    int parse_USGraph(std::string file_path, USGraph& graph);
 }
 
 #endif // PARSE_H

--- a/parse.h
+++ b/parse.h
@@ -14,8 +14,8 @@ namespace snu {
     const int PARSE_FAILURE_ADD_VERTEX = 4;
     const int PARSE_FAILURE_ADD_EDGE = 5;
 
-    int parse_DSGraph(std::string file_path, DSGraph& graph);
-    int parse_USGraph(std::string file_path, USGraph& graph);
+    int parseDSGraph(std::string file_path, DSGraph& graph);
+    int parseUSGraph(std::string file_path, USGraph& graph);
 }
 
 #endif // PARSE_H


### PR DESCRIPTION
이슈 #7 에서 제시한 개선 사항들을 바탕으로 `main.cpp`, `parse.h`, `parse.cpp`를 수정했습니다.
- 이제 입력 데이터를 command-line argument로 전달합니다. `main`에 데이터가 하드코딩되어 있었을 때와 달리 입력 데이터가 어떤 종류의 그래프인지(directed/undirected) 알 수 없기 때문에 이 또한 옵션으로 넘겨주게 되었습니다.
- `parseDSGraph`와 `parseUSGraph` 및 보조함수들의 프로토타입이 수정되었습니다. 이제 `parseXXGraph`는 그래프의 포인터 대신 상태값을 반환합니다. 이 값을 보고 파싱이 정상적으로 완료되었는지, 그렇지 않다면 파싱이 어떤 문제로 인해 중단되었는지 알 수 있습니다.
```cpp
XXGraph* parseXXGraph(string file_path);             // 수정 전
int parseXXGraph(string file_path, XXGraph& graph);  // 수정 후

// 아래는 `parse.h`에 정의된 상태값의 목록입니다.
const int PARSE_SUCCESS = 0;                   // 정상적으로 완료된 경우
const int PARSE_FAILURE_NO_INPUT = 1;          // 입력 파일이 존재하지 않는 경우
const int PARSE_FAILURE_INVALID_INPUT = 2;     // 입력 데이터에 문제가 있는 경우
const int PARSE_FAILURE_INVALID_FILETYPE = 3;  // 지원하지 않는 파일 형식인 경우
const int PARSE_FAILURE_ADD_VERTEX = 4;        // `add_vertex` 함수가 1을 반환한 경우
const int PARSE_FAILURE_ADD_EDGE = 5;          // `add_edge` 함수가 1을 반환한 경우
```

*p.s.* `parse`를 수정하는 김에 이슈 #5 에서 지적해주신 스타일 가이드 위반 사항들을 일부 고쳐보았습니다.